### PR TITLE
Store the remote regions URL in constant

### DIFF
--- a/src/Service/BrefRegionProvider.php
+++ b/src/Service/BrefRegionProvider.php
@@ -7,8 +7,10 @@ namespace Runtime\BrefLayer\Service;
  */
 class BrefRegionProvider
 {
+    private const JSON_REGIONS_URL = 'https://raw.githubusercontent.com/brefphp/bref/master/runtime/layers/regions.json';
+
     public function getAll(): array
     {
-        return json_decode(file_get_contents('https://raw.githubusercontent.com/brefphp/bref/master/runtime/layers/regions.json'), true);
+        return json_decode(file_get_contents(self::JSON_REGIONS_URL), true);
     }
 }


### PR DESCRIPTION
Just a very little enhancement for now.

Store the JSON regions URL into a constant, for improving the readability and reduce the line length when calling file_get_contents.

Hope it helps @Nyholm 😊